### PR TITLE
fix app installation on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ ifeq ($(DETECTED_OS),Windows)
     ACTIVATE = .\env\Scripts\activate
 else
     PYTHON = python3
+    VENV_PYTHON_BIN= ./env/bin/python
     ACTIVATE = . env/bin/activate
 endif
 
@@ -24,11 +25,11 @@ activate:
 
 # Install required modules
 install:
-	pip install -r requirements.txt
+	$(VENV_PYTHON_BIN) -m pip install -r requirements.txt
 
 # Run the main.py script
 run:
-	$(PYTHON) main.py --ui
+	$(VENV_PYTHON_BIN) main.py --ui
 
 # Delete the virtual environment
 clean:

--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ Welcome to Skirnir, a sophisticated Open Source Intelligence (OSINT) tool design
 - [Interface](#interface)
 - [License](#licence)
 
-
-#
-
 # Usage
 
 <a id="installation"></a>
@@ -39,6 +36,7 @@ To install the required dependencies, navigate to the project directory and :
 **Linux** : 
 run the following command in a terminal:
 ```shell
+chmod +x launcher-linux.sh
 sh launcher-linux.sh
 ```
 

--- a/launcher-linux.sh
+++ b/launcher-linux.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 
+## abort on nonzero exitstatus
+set -o errexit
+## abort on unbound variable
+set -o nounset
+
+####################################################
+#                    Parameters
+####################################################
+
+VENV_PYTHON_PATH=${VENV_PYTHON_PATH:-./env/bin/python}
+
+####################################################
+#              Function declaration
+####################################################
+
 is_debian() {
+## check if os is debian
     if [ -f /etc/debian_version ]; then
         return 0
     else
@@ -8,16 +24,27 @@ is_debian() {
     fi
 }
 
-sudo apt -y install python3
-sudo apt -y install make
-sudo apt -y install python3.11-venv
-sudo apt -y install python3-pip
+install_app_dependencies() {
+## install pip packages
+    sudo apt -y install python3 \
+        make \
+        python3.11-venv \
+        python3-pip \
 
-if is_debian; then
-    sudo apt -y install libgl1-mesa-glx
-fi
+    if is_debian; then
+        sudo apt -y install libgl1-mesa-glx
+    fi
+}
 
-make all
+####################################################
+#              Main function logic
+####################################################
 
-echo "#!/bin/bash
-make run" > launcher-linux.sh
+install_app_dependencies
+
+## create python virtualenv
+python3 -m venv env
+## install pip packages (use python exec path in the virtualenv)
+${VENV_PYTHON_PATH} -m pip install -r requirements.txt
+## start main programm
+${VENV_PYTHON_PATH} main.py --ui


### PR DESCRIPTION
fixing app installation and start from launcher-linux.sh and makefile on linux only (Windows method not changed).

Using python venv path instead of classic python to start the app and install pip dependencies.